### PR TITLE
رفع چندتا غلط املایی و نگارشی کوچیک

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,7 @@ function App() {
       <Alert message="کلمه وارد شده کوتاه تر از حد انتظار است" isOpen={isNotEnoughLetters} />
       <Alert message="کلمه وارد شده صحیح نیست" isOpen={isWordNotFoundAlertOpen} />
       <Alert
-        message={`بنظر میرسه شما باختید💔 کلمه مورد نظر : ${solution}`}
+        message={`به نظر می‌رسه شما باختید💔 کلمه مورد نظر : ${solution}`}
         isOpen={isGameLost}
       />
       <Alert
@@ -121,7 +121,7 @@ function App() {
           className="h-6 w-6 cursor-pointer animate-pulse"
           onClick={() => setIsInfoModalOpen(true)}
         />
-        <h1 className="text-xl grow font-light text-center">وردل ، اما با کلمات فارسی</h1>
+        <h1 className="text-xl grow font-light text-center">وردل، اما با کلمات فارسی</h1>
         <MenuAlt2Icon
           className="h-6 w-6 cursor-pointer -rotate-180"
           onClick={() => setIsStatsModalOpen(true)}

--- a/src/components/modals/AboutModal.tsx
+++ b/src/components/modals/AboutModal.tsx
@@ -57,7 +57,7 @@ export const AboutModal = ({ isOpen, handleClose }: Props) => {
                     as="h3"
                     className="text-lg leading-6 font-medium text-gray-900 mr-4"
                   >
-                    درباره وردل ، نسخه ای فارسی از بازی wordle
+                    درباره وردل، نسخه‌ای فارسی از بازی wordle
                   </Dialog.Title>
                   <div className="mt-2">
                     <p className="text-sm text-gray-500 text-justify">
@@ -71,7 +71,7 @@ export const AboutModal = ({ isOpen, handleClose }: Props) => {
                         >
                           مهدی 
                         </a>{' '}
-                        با تایپ اسکریپت ، ری اکت جی اس ، تایلویند 
+                        با تایپ اسکریپت، ری اکت جی اس و تیلویند 
                         توسعه داده شده است.
                       به قول خارجیا جاست اینجوی 😇
                       </p>
@@ -81,7 +81,7 @@ export const AboutModal = ({ isOpen, handleClose }: Props) => {
                           href="https://github.com/PersianWordle"
                           className="underline font-bold pl-4"
                         >
-                          گیت هاپ
+                          گیت هاب
                         </a>
                         |
                         <a


### PR DESCRIPTION
- قبل از ویرگول (و کلاً علامت‌های نگارشی) نباید فاصله باشه. (https://panevis.ir/1392/08/%da%a9%d8%a7%d8%b1%d8%a8%d8%b1%d8%af-%d9%86%d8%b4%d8%a7%d9%86%d9%87-%d9%88%db%8c%d8%b1%da%af%d9%88%d9%84%d8%8c-%da%a9%d8%a7%d9%85%d8%a7-%db%8c%d8%a7-%d8%af%d8%b1%d9%86%da%af%e2%80%8c%d9%86%d9%85%d8%a7/)
- گیت‌هاپ => گیت‌هاب
- تایلویند => تِیلویند